### PR TITLE
Add workflow_dispatch to chart_release.yaml workflow

### DIFF
--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'charts/**'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow configuration by enabling manual triggering of the chart release workflow. This allows users to run the workflow on demand through the GitHub UI.