### PR TITLE
Add contents.write permission to Zola site generation workflow

### DIFF
--- a/.github/workflows/zola_publish.yml
+++ b/.github/workflows/zola_publish.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration for publishing the Zola site. It adds explicit write permissions for repository contents to the workflow.