### PR TITLE
Skip uploading Helm charts which already have releases even if CR thinks it's missing

### DIFF
--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -32,5 +32,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a small update to the Helm chart release workflow. The change ensures that existing charts are skipped during the release process by setting the `skip_existing` parameter to `true`.