### PR TITLE
Remove Addon Version Authority from arr-common library chart

### DIFF
--- a/charts/arr-common/values.yaml
+++ b/charts/arr-common/values.yaml
@@ -91,7 +91,7 @@ exports:
       enabled: false
       image:
         repository: ghcr.io/onedr0p/exportarr
-        tag: v2.0.1
+        tag: latest
         pullPolicy: IfNotPresent
       port: 9707
       env:
@@ -102,7 +102,7 @@ exports:
       enabled: false
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.40.0
+        tag: latest
         pullPolicy: IfNotPresent
       env: {}
       # Name of a pre-existing Kubernetes Secret whose keys will be loaded as


### PR DESCRIPTION
This is to prevent Renovate insisting it bumps this version and then triggering a rebuild of every consumer to bump the chart library version and thus causing a ripple effect of PR generation and version bumps all because of one hard-coded version in a shared component

Ultimately the goal here is to ensure that the arr-common library of only ever changed for an actually functional reason and not just because a version has changed in a downstream component we reference. It is a strongly enforced rule of thumb that charts in this repository which consume library charts should re-declare explicit tested versions of addons assuming the authority for those versions. The authority does not lie with the library.

This alleviates the main complaint with TrueCharts where a million PRs are raised for multiple apps because some unrelated component you do not use is patched.