### PR TITLE
Fix missing Helm Repository for Jankcloud during chart-releaser process

### DIFF
--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -28,6 +28,9 @@ jobs:
           git config user.name "JankBot"
           git config user.email "jankbot@users.noreply.github.com"
 
+      - name: Add jankcloud Helm repository
+        run: helm repo add jankcloud https://jankcloud.github.io/charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:


### PR DESCRIPTION
This pull request makes a small update to the Helm chart release workflow. It adds a step to register the `jankcloud` Helm repository before running the chart releaser action.

- Workflow improvement:
  * [`.github/workflows/chart_release.yaml`](diffhunk://#diff-f60133b7daed3046a600511f6e20cee698b40518535271702b3ddca77314dd26R31-R33): Added a step to add the `jankcloud` Helm repository using `helm repo add` before the chart release process.