### PR TITLE
Add specific chart for testing arr-common library chart

### DIFF
--- a/.github/workflows/test_charts.yaml
+++ b/.github/workflows/test_charts.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'charts/**'
+      - 'tests/**'
   workflow_dispatch:
 
 permissions:
@@ -30,6 +31,15 @@ jobs:
                 - name: jankcloud
                   url: https://jankcloud.github.io/charts
             unit_tests_enabled: true
+          - chart: arr-common
+            chart_path: tests/arr-common
+            unit_tests_enabled: true
+            dependencies:
+              fetch: true
+              repositories:
+                - name: jankcloud
+                  url: https://jankcloud.github.io/charts
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/tests/arr-common/Chart.yaml
+++ b/tests/arr-common/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: arr-common-test
+description: A Helm chart for testing arr-common library chart
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+home: https://github.com/jankcloud/charts
+sources:
+  - https://github.com/jankcloud/charts/tree/main/charts/arr-common
+keywords:
+  - arr-common
+  - library
+maintainers:
+  - name: jankcloud
+    url: https://github.com/jankcloud
+dependencies:
+  - name: arr-common
+    version: "0.1.0"
+    repository: "https://jankcloud.github.io/charts"
+    import-values:
+      - defaults

--- a/tests/arr-common/templates/deployment.yaml
+++ b/tests/arr-common/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "arr-common.deployment" . }}

--- a/tests/arr-common/templates/ingress.yaml
+++ b/tests/arr-common/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "arr-common.ingress" . }}

--- a/tests/arr-common/templates/pvc.yaml
+++ b/tests/arr-common/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "arr-common.pvc" . }}

--- a/tests/arr-common/templates/service.yaml
+++ b/tests/arr-common/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "arr-common.service" . }}

--- a/tests/arr-common/templates/servicemonitor.yaml
+++ b/tests/arr-common/templates/servicemonitor.yaml
@@ -1,0 +1,1 @@
+{{- include "arr-common.servicemonitor" . }}

--- a/tests/arr-common/tests/deployment_test.yaml
+++ b/tests/arr-common/tests/deployment_test.yaml
@@ -1,0 +1,400 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+tests:
+
+  - it: renders a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: uses the release name and chart name in the resource name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test
+
+  - it: carries the standard Helm label set
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: arr-common-test
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+
+  - it: defaults to Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: allows strategy to be overridden to RollingUpdate
+    set:
+      strategy:
+        type: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: renders no volumes or volumeMounts when persistence is disabled
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: mounts /config when persistence.config is enabled
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 4Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-arr-common-test-config
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /config
+
+  - it: mounts additionalVolumes into the main container
+    set:
+      additionalVolumes:
+        - name: tv
+          mountPath: /tv
+          existingClaim: existing-tv
+          readOnly: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tv
+            persistentVolumeClaim:
+              claimName: existing-tv
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tv
+            mountPath: /tv
+
+  - it: uses generated claim name when existingClaim is absent
+    set:
+      additionalVolumes:
+        - name: downloads
+          mountPath: /downloads
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: downloads
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-arr-common-test-downloads
+
+  - it: mounts additionalVolumes as readOnly when readOnly is true
+    set:
+      additionalVolumes:
+        - name: nfs-media
+          mountPath: /media
+          existingClaim: shared-media
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nfs-media
+            mountPath: /media
+            readOnly: true
+
+  - it: appends extraVolumeMounts to the main container
+    set:
+      extraVolumes:
+        - name: custom-scripts
+          configMap:
+            name: arr-common-scripts
+      extraVolumeMounts:
+        - name: custom-scripts
+          mountPath: /scripts
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-scripts
+            mountPath: /scripts
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-scripts
+            configMap:
+              name: arr-common-scripts
+
+  - it: renders initContainers when provided
+    set:
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 1000:1000 /config"]
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      persistence:
+        config:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36
+
+  - it: appends extra sidecar containers when provided
+    set:
+      sidecars:
+        - name: log-shipper
+          image: fluent/fluent-bit:3.0
+          env:
+            - name: SOME_VAR
+              value: some-value
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: log-shipper
+
+  - it: does not render a gluetun container by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: gluetun
+          any: true
+
+  - it: injects gluetun container with inline env vars when enabled
+    set:
+      gluetun:
+        enabled: true
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.40.0
+          pullPolicy: IfNotPresent
+        env:
+          VPN_SERVICE_PROVIDER: mullvad
+          VPN_TYPE: wireguard
+          WIREGUARD_PRIVATE_KEY: "s3cr3t"
+        existingSecret: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: gluetun
+          any: true
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: gluetun
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.add[0]
+          value: NET_ADMIN
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: VPN_SERVICE_PROVIDER
+            value: mullvad
+
+  - it: does not add a gluetun-credentials volume in inline env mode
+    set:
+      gluetun:
+        enabled: true
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.40.0
+          pullPolicy: IfNotPresent
+        env:
+          VPN_SERVICE_PROVIDER: mullvad
+        existingSecret: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: loads gluetun credentials from an existing secret via envFrom
+    set:
+      gluetun:
+        enabled: true
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.40.0
+          pullPolicy: IfNotPresent
+        env: {}
+        existingSecret: my-vpn-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].envFrom[0].secretRef.name
+          value: my-vpn-secret
+      - notExists:
+          path: spec.template.spec.containers[1].env
+
+  - it: mounts a gluetun-credentials volume when existingSecret is set
+    set:
+      gluetun:
+        enabled: true
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.40.0
+          pullPolicy: IfNotPresent
+        env: {}
+        existingSecret: my-vpn-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gluetun-credentials
+            secret:
+              secretName: my-vpn-secret
+
+  - it: does not render an exportarr container by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: exportarr
+          any: true
+
+  - it: injects exportarr sidecar when enabled
+    set:
+      exportarr:
+        enabled: true
+        image:
+          repository: ghcr.io/onedr0p/exportarr
+          tag: v2.0.1
+          pullPolicy: IfNotPresent
+        port: 9707
+        env:
+          URL: "http://localhost:8989"
+          APIKEY: "abc123"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: exportarr
+          any: true
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: exportarr
+      - contains:
+          path: spec.template.spec.containers[1].ports
+          content:
+            name: exportarr
+            containerPort: 9707
+            protocol: TCP
+
+  - it: exportarr container does not receive additionalVolumes mounts
+    set:
+      exportarr:
+        enabled: true
+        image:
+          repository: ghcr.io/onedr0p/exportarr
+          tag: v2.0.1
+          pullPolicy: IfNotPresent
+        port: 9707
+        env:
+          URL: "http://localhost:8989"
+          APIKEY: "abc123"
+      additionalVolumes:
+        - name: tv
+          mountPath: /tv
+          existingClaim: existing-tv
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].volumeMounts
+
+  - it: applies nodeSelector when set
+    set:
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+
+  - it: applies tolerations when set
+    set:
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: media
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: media
+            effect: NoSchedule
+
+  - it: applies affinity when set
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: storage
+                    operator: In
+                    values:
+                      - fast
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.affinity
+
+  - it: respects fullnameOverride
+    set:
+      fullnameOverride: my-arr-common
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-arr-common
+
+  - it: respects nameOverride
+    set:
+      nameOverride: custom-arr
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-custom-arr
+
+  - it: uses default service account when serviceAccount is not configured
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: uses configured service account when serviceAccount.create is true
+    set:
+      serviceAccount:
+        create: true
+        name: custom-service-account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-service-account
+
+  - it: falls back to chart appVersion when image.tag is empty
+    set:
+      image:
+        repository: ghcr.io/nonexistant/repository
+        tag: ""
+        pullPolicy: IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/nonexistant/repository:0.1.0

--- a/tests/arr-common/tests/ingress_test.yaml
+++ b/tests/arr-common/tests/ingress_test.yaml
@@ -1,0 +1,190 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+tests:
+
+  - it: does not render an Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a networking.k8s.io/v1 Ingress when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+
+  - it: sets the release name and chart name as the Ingress name
+    set:
+      ingress:
+        enabled: true
+        hosts: []
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test
+
+  - it: sets ingressClassName when provided
+    set:
+      ingress:
+        enabled: true
+        className: nginx
+        hosts: []
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: does not set ingressClassName when className is empty
+    set:
+      ingress:
+        enabled: true
+        className: ""
+        hosts: []
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: renders host rules correctly
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: arr.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+
+  - it: defaults pathType to Prefix when omitted
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+
+  - it: points the backend at the release service http port
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-arr-common-test
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+
+  - it: renders multiple paths for a single host
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+              - path: /api
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /api
+
+  - it: renders multiple host rules
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.internal
+            paths:
+              - path: /
+                pathType: Prefix
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: arr.internal
+      - equal:
+          path: spec.rules[1].host
+          value: arr.example.com
+
+  - it: renders TLS section when tls is set
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: arr.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - secretName: arr-tls
+            hosts:
+              - arr.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: arr-tls
+      - contains:
+          path: spec.tls[0].hosts
+          content: arr.example.com
+
+  - it: does not render a TLS section when tls is empty
+    set:
+      ingress:
+        enabled: true
+        hosts: []
+        tls: []
+    asserts:
+      - notExists:
+          path: spec.tls
+
+  - it: applies ingress annotations when set
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        hosts: []
+    asserts:
+      - equal:
+          path: 'metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]'
+          value: "0"

--- a/tests/arr-common/tests/pvc_test.yaml
+++ b/tests/arr-common/tests/pvc_test.yaml
@@ -1,0 +1,123 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+tests:
+
+  - it: renders no PVCs when persistence is disabled and additionalVolumes is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the config PVC when persistence.config.enabled is true
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 4Gi
+          accessMode: ReadWriteOnce
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test-config
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 4Gi
+
+  - it: sets storageClassName on config PVC when storageClass is provided
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 2Gi
+          storageClass: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+
+  - it: does not set storageClassName when storageClass is empty
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 2Gi
+          storageClass: ""
+    asserts:
+      - notExists:
+          path: spec.storageClassName
+
+  - it: sets volumeName on config PVC when volumeName is provided
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 2Gi
+          volumeName: my-config-pv
+    asserts:
+      - equal:
+          path: spec.volumeName
+          value: my-config-pv
+
+  - it: creates a PVC for an additionalVolume without existingClaim
+    set:
+      additionalVolumes:
+        - name: tv
+          mountPath: /tv
+          pvc:
+            accessMode: ReadWriteMany
+            size: 5Ti
+            storageClass: nfs-client
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test-tv
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Ti
+      - equal:
+          path: spec.storageClassName
+          value: nfs-client
+
+  - it: does not create a PVC for an additionalVolume that has an existingClaim
+    set:
+      additionalVolumes:
+        - name: tv
+          mountPath: /tv
+          existingClaim: my-tv-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders one PVC per auto-provisioned volume plus the config PVC
+    set:
+      persistence:
+        config:
+          enabled: true
+          size: 2Gi
+      additionalVolumes:
+        - name: tv
+          mountPath: /tv
+          pvc:
+            size: 1Ti
+        - name: downloads
+          mountPath: /downloads
+          pvc:
+            size: 500Gi
+        - name: existing-media
+          mountPath: /media
+          existingClaim: shared-media
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/tests/arr-common/tests/service_test.yaml
+++ b/tests/arr-common/tests/service_test.yaml
@@ -1,0 +1,83 @@
+suite: Service
+templates:
+  - templates/service.yaml
+tests:
+
+  - it: renders a ClusterIP Service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: uses the release name and chart name for the service name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test
+
+  - it: exposes app service port as http
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 8989
+            targetPort: http
+            protocol: TCP
+
+  - it: does not expose an exportarr port by default
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: exportarr
+          any: true
+
+  - it: adds exportarr port when exportarr is enabled
+    set:
+      exportarr:
+        enabled: true
+        port: 9707
+        image:
+          repository: ghcr.io/onedr0p/exportarr
+          tag: v2.0.1
+          pullPolicy: IfNotPresent
+        env:
+          URL: "http://localhost:8989"
+          APIKEY: ""
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: exportarr
+            port: 9707
+            targetPort: exportarr
+            protocol: TCP
+
+  - it: applies service annotations when set
+    set:
+      service:
+        port: 8989
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: arr.example.com
+    asserts:
+      - equal:
+          path: 'metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]'
+          value: arr.example.com
+
+  - it: has no annotations when none are configured
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: allows service type to be changed to LoadBalancer
+    set:
+      service:
+        type: LoadBalancer
+        port: 8989
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer

--- a/tests/arr-common/tests/servicemonitor_test.yaml
+++ b/tests/arr-common/tests/servicemonitor_test.yaml
@@ -1,0 +1,136 @@
+suite: ServiceMonitor
+templates:
+  - templates/servicemonitor.yaml
+tests:
+
+  - it: does not render a ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a monitoring.coreos.com/v1 ServiceMonitor when enabled
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - isAPIVersion:
+          of: monitoring.coreos.com/v1
+
+  - it: uses the release name and chart name for the ServiceMonitor name
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-arr-common-test
+
+  - it: selector matches the release labels
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - isSubset:
+          path: spec.selector.matchLabels
+          content:
+            app.kubernetes.io/name: arr-common-test
+            app.kubernetes.io/instance: RELEASE-NAME
+
+  - it: scrapes the http endpoint with default interval and timeout
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 10s
+
+  - it: respects custom interval and scrapeTimeout
+    set:
+      serviceMonitor:
+        enabled: true
+        interval: 60s
+        scrapeTimeout: 20s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 60s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 20s
+
+  - it: applies extra labels to the ServiceMonitor
+    set:
+      serviceMonitor:
+        enabled: true
+        labels:
+          prometheus: kube-prometheus
+    asserts:
+      - equal:
+          path: metadata.labels["prometheus"]
+          value: kube-prometheus
+
+  - it: applies annotations to the ServiceMonitor
+    set:
+      serviceMonitor:
+        enabled: true
+        annotations:
+          argocd.argoproj.io/sync-wave: "5"
+    asserts:
+      - equal:
+          path: 'metadata.annotations["argocd.argoproj.io/sync-wave"]'
+          value: "5"
+
+  - it: has only one endpoint when exportarr is disabled
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.endpoints
+          count: 1
+      - notContains:
+          path: spec.endpoints
+          content:
+            port: exportarr
+          any: true
+
+  - it: adds an exportarr endpoint when exportarr and serviceMonitor are both enabled
+    set:
+      serviceMonitor:
+        enabled: true
+        interval: 30s
+        scrapeTimeout: 10s
+      exportarr:
+        enabled: true
+        port: 9707
+        image:
+          repository: ghcr.io/onedr0p/exportarr
+          tag: v2.0.1
+          pullPolicy: IfNotPresent
+        env:
+          URL: "http://localhost:8989"
+          APIKEY: "abc123"
+    asserts:
+      - lengthEqual:
+          path: spec.endpoints
+          count: 2
+      - equal:
+          path: spec.endpoints[1].port
+          value: exportarr
+      - equal:
+          path: spec.endpoints[1].interval
+          value: 30s
+      - equal:
+          path: spec.endpoints[1].scrapeTimeout
+          value: 10s

--- a/tests/arr-common/values.yaml
+++ b/tests/arr-common/values.yaml
@@ -1,0 +1,96 @@
+image:
+  repository: ghcr.io/nonexistant/repository
+  tag: anulltag
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: "America/New_York"
+
+service:
+  type: ClusterIP
+  port: 8989
+  annotations: {}
+
+persistence:
+  config:
+    enabled: false
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    volumeName: ""
+
+additionalVolumes: []
+  # - name: tv
+  #   mountPath: /tv
+  #   existingClaim: ""
+  #   readOnly: false
+  #   pvc:
+  #     accessMode: ReadWriteMany
+  #     size: 5Ti
+  #     storageClass: nfs-client
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+probes:
+  liveness:
+    httpGet:
+      path: /ping
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+  readiness:
+    httpGet:
+      path: /ping
+      port: http
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  annotations: {}
+
+exportarr:
+  enabled: false
+  image:
+    repository: ghcr.io/onedr0p/exportarr
+    tag: v2.3.0
+    pullPolicy: IfNotPresent
+  port: 9707
+  env:
+    URL: "http://localhost:8989"
+    APIKEY: ""
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+initContainers: []
+sidecars: []
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
This pull request introduces a comprehensive test suite for the `arr-common` Helm library chart by adding a dedicated test chart and associated test cases. The changes ensure that the `arr-common` chart's templates and features are thoroughly validated using Helm unit tests, improving reliability and maintainability. The workflow for running these tests is also updated to include the new test chart.

**Test infrastructure and workflow updates:**

* The GitHub Actions workflow `.github/workflows/test_charts.yaml` is updated to trigger on changes to both `charts/**` and `tests/**` paths, and to add the `arr-common` test chart (`tests/arr-common`) to the test matrix with appropriate repository dependencies. [[1]](diffhunk://#diff-5732336ca881572c2d50a01f9fe02e86e7895dcf4e3a16aaa32f3a61d0160f57R7) [[2]](diffhunk://#diff-5732336ca881572c2d50a01f9fe02e86e7895dcf4e3a16aaa32f3a61d0160f57R34-R42)

**New test chart and templates:**

* A new test chart `arr-common-test` is added under `tests/arr-common`, including a `Chart.yaml` that declares a dependency on the `arr-common` library chart.
* The test chart includes template files that simply include the corresponding templates from the `arr-common` library (`deployment.yaml`, `ingress.yaml`, `pvc.yaml`, `service.yaml`, `servicemonitor.yaml`). [[1]](diffhunk://#diff-5a02388863a31771be60fd6bf40150dd2dbb981bb58db8a428f4ddc2548a315bR1) [[2]](diffhunk://#diff-ab0be62be41b6b0c6b783bebdb883513426b707059e20c2d2bad934be2540746R1) [[3]](diffhunk://#diff-728d189cffb70d9fdc6f4ae3c7a525da2160537c874808d8494af4f8d03c4988R1) [[4]](diffhunk://#diff-fa682ad6f779f35c0ca3606715cbf56dfdac46c976a26ee4e32fc7cf1d3c8943R1) [[5]](diffhunk://#diff-eb75407b6924a1917ba2b3e8bfcd0af35567c2611f2c482d7a21c00548cbc51eR1)

**Extensive Helm unit tests:**

* Tests are added for all major template types:
  - Deployment: Validates resource naming, labels, strategies, volume mounts, sidecars, gluetun and exportarr containers, service account handling, and more.
  - Ingress: Covers enabling/disabling, host/path rules, ingress class, TLS, and annotations.
  - PVC: Validates config and additional volume claims, storage classes, and auto-provisioning logic.
  - Service: Checks service type, ports, annotations, and exportarr integration.