### PR TITLE
Add missing CODEOWNERS files

### DIFF
--- a/charts/arr-common/CODEOWNERS
+++ b/charts/arr-common/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Matthew-Beckett

--- a/charts/radarr/CODEOWNERS
+++ b/charts/radarr/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Matthew-Beckett

--- a/charts/sonarr/CODEOWNERS
+++ b/charts/sonarr/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Matthew-Beckett


### PR DESCRIPTION
This pull request makes a small change by adding `@Matthew-Beckett` as the code owner for the `arr-common`, `radarr`, and `sonarr` charts.