### PR TITLE
Add Helm lock file maintenance and sub chart archive publishing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,14 @@
   ],
   "gitIgnoredAuthors": ["jankbot@users.noreply.github.com"],
   "prHourlyLimit": 0,
-  "helm-values": {
-    "managerFilePatterns": ["/^charts\\/[^\\/]+\\/values\\.ya?ml$/"]
+  "helmv3" : {
+    "managerFilePatterns": ["/(^|/)Chart\\.ya?ml$/"],
+    "postUpdateOptions": ["helmUpdateSubChartArchives"]
   },
-  "kubernetes": {
-    "managerFilePatterns": ["/^charts\\/[^\\/]+\\/values\\.ya?ml$/"]
+  "helm-values" : {
+    "managerFilePatterns": [
+      "/(^|/)values\\.ya?ml$/"
+    ],
+    "pinDigests": true
   }
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve how Renovate manages Helm and Kubernetes-related files. The changes reorganize and enhance the handling of Helm charts and values files, ensuring more accurate updates and digest pinning.

**Helm and Kubernetes configuration improvements:**

* Changed the configuration from using a generic `helm-values` and `kubernetes` section to separate `helmv3` and `helm-values` sections for better clarity and control. (`renovate.json`)
* Updated `helmv3` to match `Chart.yaml` files anywhere in the repository and added the `helmUpdateSubChartArchives` post-update option for improved subchart handling. (`renovate.json`)
* Updated `helm-values` to match `values.yaml` files anywhere in the repository and enabled `pinDigests` for more secure dependency management. (`renovate.json`)