### PR TITLE
Strip OCI Image Digest SHA when syncing Renovate dependency bump operations into Chart.yaml appVersion property

### DIFF
--- a/.github/workflows/renovate_bump_chart_versions.yaml
+++ b/.github/workflows/renovate_bump_chart_versions.yaml
@@ -79,6 +79,7 @@ jobs:
             fi
 
             normalized_app_version="${current_tag#v}"
+            normalized_app_version="${normalized_app_version%%@*}"
 
             base_version="$(git show "${{ github.event.pull_request.base.sha }}:${chart_file}" 2>/dev/null | yq -r '.version // ""' - 2>/dev/null || true)"
             target_version="$(bump_patch "$base_version")"


### PR DESCRIPTION
This pull request introduces a small but important change to the version normalization process in the `renovate_bump_chart_versions.yaml` workflow. The update ensures that any suffix after an `@` symbol in the app version is removed, which helps maintain consistent version formatting.

* Improved version normalization: The workflow now strips any `@` suffix from `normalized_app_version` to ensure only the base version is used for subsequent operations.