### PR TITLE
Improve Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
     "config:recommended",
     "customManagers:helmChartYamlAppVersions",
     "helpers:pinGitHubActionDigests",
+    "docker:pinDigests",
+    ":configMigration",
+    ":pinDevDependencies",
+    "abandonments:recommended",
+    ":maintainLockFilesWeekly"
   ],
   "gitIgnoredAuthors": ["jankbot@users.noreply.github.com"],
   "prHourlyLimit": 0,
@@ -23,5 +28,14 @@
       "/(^|/)values\\.ya?ml$/"
     ],
     "pinDigests": true
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Disable digest pinning for latest docker images in helm-values",
+      "matchDatasources": ["docker"],
+      "matchVersions": ["/^latest$/"],
+      "matchFileNames": ["**/values.yaml", "**/values.yml"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve dependency management automation. The main changes involve enabling additional recommended settings, enhancing Docker image handling, and introducing package rules for more granular control.

**Configuration improvements:**

* Added several recommended and maintenance-related presets to the `extends` array, including Docker digest pinning, config migration, dev dependency pinning, abandonment detection, and weekly lock file maintenance.

**Docker image handling:**

* Added a `packageRules` section to disable digest pinning for Docker images tagged as `latest` in Helm values files (`values.yaml` and `values.yml`), while keeping digest pinning enabled elsewhere.