### PR TITLE
Update downstream consumers of `arr-common` to `0.2.0` and the new `metrics` interface

### DIFF
--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -3,7 +3,7 @@ name: bazarr
 description: >
   A Helm chart for deploying Bazarr
 type: application
-version: 1.3.0
+version: 1.4.0
 # renovate: image=ghcr.io/linuxserver/bazarr
 appVersion: 1.5.6
 home: https://www.bazarr.media
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -1,6 +1,6 @@
 # bazarr
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.6](https://img.shields.io/badge/AppVersion-1.5.6-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.6](https://img.shields.io/badge/AppVersion-1.5.6-informational?style=flat-square)
 
 A Helm chart for deploying Bazarr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Bazarr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -32,13 +32,6 @@ A Helm chart for deploying Bazarr
 | env.PGID | string | `"1000"` |  |
 | env.PUID | string | `"1000"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.URL | string | `"http://localhost:6767"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -57,6 +50,13 @@ A Helm chart for deploying Bazarr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.URL | string | `"http://localhost:6767"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/bazarr/tests/deployment_test.yaml
+++ b/charts/bazarr/tests/deployment_test.yaml
@@ -43,9 +43,9 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /
 
-  - it: does not render an exportarr sidecar by default
+  - it: does not render a metrics exporter sidecar by default
     asserts:
       - notContains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter

--- a/charts/bazarr/values.schema.json
+++ b/charts/bazarr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -600,81 +660,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:6767",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -844,6 +829,81 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:6767",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1204,7 +1264,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/bazarr/values.yaml
+++ b/charts/bazarr/values.yaml
@@ -71,7 +71,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -3,7 +3,7 @@ name: cleanuparr
 description: >
   A Helm chart for deploying Cleanuparr
 type: application
-version: 1.2.2
+version: 1.3.0
 # renovate: image=ghcr.io/cleanuparr/cleanuparr
 appVersion: 2.9.2
 home: https://github.com/Cleanuparr/Cleanuparr
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/cleanuparr/README.md
+++ b/charts/cleanuparr/README.md
@@ -1,6 +1,6 @@
 # cleanuparr
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 A Helm chart for deploying Cleanuparr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Cleanuparr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -31,13 +31,6 @@ A Helm chart for deploying Cleanuparr
 | affinity | object | `{}` |  |
 | env.PORT | string | `"11011"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.URL | string | `"http://localhost:11011"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -56,6 +49,13 @@ A Helm chart for deploying Cleanuparr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.URL | string | `"http://localhost:11011"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/cleanuparr/tests/deployment_test.yaml
+++ b/charts/cleanuparr/tests/deployment_test.yaml
@@ -41,12 +41,12 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /
 
-  - it: does not render an exportarr sidecar by default
+  - it: does not render a metrics exporter sidecar by default
     asserts:
       - notContains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter
 
   - it: mounts torrents volume when set via additionalVolumes
     set:

--- a/charts/cleanuparr/values.schema.json
+++ b/charts/cleanuparr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -593,81 +653,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:11011",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -837,6 +822,81 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:11011",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1197,7 +1257,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/cleanuparr/values.yaml
+++ b/charts/cleanuparr/values.yaml
@@ -75,7 +75,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -3,7 +3,7 @@ name: lidarr
 description: >
   A Helm chart for deploying Lidarr
 type: application
-version: 1.2.0
+version: 1.3.0
 # renovate: image=ghcr.io/linuxserver/lidarr
 appVersion: 8.1.2135
 home: https://lidarr.audio
@@ -22,7 +22,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -1,6 +1,6 @@
 # lidarr
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2135](https://img.shields.io/badge/AppVersion-8.1.2135-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2135](https://img.shields.io/badge/AppVersion-8.1.2135-informational?style=flat-square)
 
 A Helm chart for deploying Lidarr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Lidarr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -32,14 +32,6 @@ A Helm chart for deploying Lidarr
 | env.PGID | string | `"1000"` |  |
 | env.PUID | string | `"1000"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.APP | string | `"lidarr"` |  |
-| exportarr.env.URL | string | `"http://localhost:8686"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -58,6 +50,14 @@ A Helm chart for deploying Lidarr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.APP | string | `"lidarr"` |  |
+| metrics.env.URL | string | `"http://localhost:8686"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/lidarr/tests/deployment_test.yaml
+++ b/charts/lidarr/tests/deployment_test.yaml
@@ -43,16 +43,16 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /ping
 
-  - it: does not render an exportarr sidecar by default
+  - it: does not render a metrics exporter sidecar by default
     asserts:
       - notContains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter
 
-  - it: renders an exportarr sidecar with APP=lidarr when enabled
+  - it: renders a metrics exporter sidecar with APP=lidarr when enabled
     set:
-      exportarr:
+      metrics:
         enabled: true
         env:
           URL: "http://localhost:8686"
@@ -62,7 +62,7 @@ tests:
       - contains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter
           any: true
       - contains:
           path: spec.template.spec.containers[1].env

--- a/charts/lidarr/values.schema.json
+++ b/charts/lidarr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -600,88 +660,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "APP": {
-              "default": "lidarr",
-              "required": [],
-              "title": "APP",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:8686",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY",
-            "APP"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -851,6 +829,88 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "APP": {
+              "default": "lidarr",
+              "required": [],
+              "title": "APP",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:8686",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY",
+            "APP"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1211,7 +1271,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/lidarr/values.yaml
+++ b/charts/lidarr/values.yaml
@@ -79,7 +79,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -3,7 +3,7 @@ name: prowlarr
 description: >
   A Helm chart for deploying Prowlarr
 type: application
-version: 1.3.0
+version: 1.4.0
 # renovate: image=ghcr.io/linuxserver/prowlarr
 appVersion: 2.3.0
 home: https://prowlarr.com
@@ -21,7 +21,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -1,6 +1,6 @@
 # prowlarr
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for deploying Prowlarr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Prowlarr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -32,14 +32,6 @@ A Helm chart for deploying Prowlarr
 | env.PGID | string | `"1000"` |  |
 | env.PUID | string | `"1000"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.APP | string | `"prowlarr"` |  |
-| exportarr.env.URL | string | `"http://localhost:9696"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -58,6 +50,14 @@ A Helm chart for deploying Prowlarr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.APP | string | `"prowlarr"` |  |
+| metrics.env.URL | string | `"http://localhost:9696"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/prowlarr/tests/deployment_test.yaml
+++ b/charts/prowlarr/tests/deployment_test.yaml
@@ -43,16 +43,16 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /ping
 
-  - it: does not render an exportarr sidecar by default
+  - it: does not render a metrics exporter sidecar by default
     asserts:
       - notContains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter
 
-  - it: renders an exportarr sidecar with APP=prowlarr when enabled
+  - it: renders a metrics exporter sidecar with APP=prowlarr when enabled
     set:
-      exportarr:
+      metrics:
         enabled: true
         env:
           URL: "http://localhost:9696"
@@ -62,7 +62,7 @@ tests:
       - contains:
           path: spec.template.spec.containers
           content:
-            name: exportarr
+            name: metrics-exporter
           any: true
       - contains:
           path: spec.template.spec.containers[1].env

--- a/charts/prowlarr/values.schema.json
+++ b/charts/prowlarr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -600,88 +660,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "APP": {
-              "default": "prowlarr",
-              "required": [],
-              "title": "APP",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:9696",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY",
-            "APP"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -851,6 +829,88 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "APP": {
+              "default": "prowlarr",
+              "required": [],
+              "title": "APP",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:9696",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY",
+            "APP"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1211,7 +1271,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -71,7 +71,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -3,7 +3,7 @@ name: radarr
 description: >
   A Helm chart for deploying Radarr
 type: application
-version: 1.2.0
+version: 1.3.0
 # renovate: image=ghcr.io/linuxserver/radarr
 appVersion: 6.0.4
 home: https://radarr.video
@@ -21,7 +21,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -1,6 +1,6 @@
 # radarr
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.0.4](https://img.shields.io/badge/AppVersion-6.0.4-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.0.4](https://img.shields.io/badge/AppVersion-6.0.4-informational?style=flat-square)
 
 A Helm chart for deploying Radarr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Radarr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -32,13 +32,6 @@ A Helm chart for deploying Radarr
 | env.PGID | string | `"1000"` |  |
 | env.PUID | string | `"1000"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.URL | string | `"http://localhost:7878"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -57,6 +50,13 @@ A Helm chart for deploying Radarr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.URL | string | `"http://localhost:7878"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/radarr/tests/service_test.yaml
+++ b/charts/radarr/tests/service_test.yaml
@@ -20,3 +20,16 @@ tests:
             port: 7878
             targetPort: http
             protocol: TCP
+
+  - it: exposes the metrics exporter port when enabled
+    set:
+      metrics:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics-exporter
+            port: 9707
+            targetPort: metrics-exporter
+            protocol: TCP

--- a/charts/radarr/tests/servicemonitor_test.yaml
+++ b/charts/radarr/tests/servicemonitor_test.yaml
@@ -17,3 +17,17 @@ tests:
           count: 1
       - isKind:
           of: ServiceMonitor
+
+  - it: renders a metrics exporter endpoint when both ServiceMonitor and metrics exporter are enabled
+    set:
+      serviceMonitor:
+        enabled: true
+      metrics:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.endpoints
+          content:
+            port: metrics-exporter
+            interval: 30s
+            scrapeTimeout: 10s

--- a/charts/radarr/values.schema.json
+++ b/charts/radarr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -600,81 +660,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:7878",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -844,6 +829,81 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:7878",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1204,7 +1264,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/radarr/values.yaml
+++ b/charts/radarr/values.yaml
@@ -79,7 +79,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarr
 description: A Helm chart for deploying Sonarr
 type: application
-version: 1.2.2
+version: 1.3.0
 # renovate: image=ghcr.io/linuxserver/sonarr
 appVersion: 4.0.17
 home: https://sonarr.tv
@@ -20,7 +20,7 @@ maintainers:
     url: https://github.com/jankcloud
 dependencies:
   - name: arr-common
-    version: "0.1.2"
+    version: "0.2.0"
     repository: "https://jankcloud.github.io/charts"
     import-values:
       - defaults

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -1,6 +1,6 @@
 # sonarr
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.17](https://img.shields.io/badge/AppVersion-4.0.17-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.17](https://img.shields.io/badge/AppVersion-4.0.17-informational?style=flat-square)
 
 A Helm chart for deploying Sonarr
 
@@ -21,7 +21,7 @@ A Helm chart for deploying Sonarr
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://jankcloud.github.io/charts | arr-common | 0.1.2 |
+| https://jankcloud.github.io/charts | arr-common | 0.2.0 |
 
 ## Values
 
@@ -32,13 +32,6 @@ A Helm chart for deploying Sonarr
 | env.PGID | string | `"1000"` |  |
 | env.PUID | string | `"1000"` |  |
 | env.TZ | string | `"America/New_York"` |  |
-| exportarr.enabled | bool | `false` |  |
-| exportarr.env.APIKEY | string | `""` |  |
-| exportarr.env.URL | string | `"http://localhost:8989"` |  |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` |  |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
-| exportarr.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
-| exportarr.port | int | `9707` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -57,6 +50,13 @@ A Helm chart for deploying Sonarr
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.env.APIKEY | string | `""` |  |
+| metrics.env.URL | string | `"http://localhost:8989"` |  |
+| metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.image.repository | string | `"ghcr.io/onedr0p/exportarr"` |  |
+| metrics.image.tag | string | `"v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520"` |  |
+| metrics.port | int | `9707` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/sonarr/values.schema.json
+++ b/charts/sonarr/values.schema.json
@@ -40,69 +40,6 @@
                   "title": "env",
                   "type": "object"
                 },
-                "exportarr": {
-                  "properties": {
-                    "enabled": {
-                      "default": false,
-                      "required": [],
-                      "title": "enabled",
-                      "type": "boolean"
-                    },
-                    "env": {
-                      "properties": {
-                        "APIKEY": {
-                          "default": "",
-                          "required": [],
-                          "title": "APIKEY",
-                          "type": "string"
-                        },
-                        "URL": {
-                          "default": "http://localhost",
-                          "required": [],
-                          "title": "URL",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "env",
-                      "type": "object"
-                    },
-                    "image": {
-                      "properties": {
-                        "pullPolicy": {
-                          "default": "IfNotPresent",
-                          "required": [],
-                          "title": "pullPolicy",
-                          "type": "string"
-                        },
-                        "repository": {
-                          "default": "ghcr.io/onedr0p/exportarr",
-                          "required": [],
-                          "title": "repository",
-                          "type": "string"
-                        },
-                        "tag": {
-                          "default": "latest",
-                          "required": [],
-                          "title": "tag",
-                          "type": "string"
-                        }
-                      },
-                      "required": [],
-                      "title": "image",
-                      "type": "object"
-                    },
-                    "port": {
-                      "default": 9707,
-                      "required": [],
-                      "title": "port",
-                      "type": "integer"
-                    }
-                  },
-                  "required": [],
-                  "title": "exportarr",
-                  "type": "object"
-                },
                 "extraVolumeMounts": {
                   "items": {
                     "required": []
@@ -248,6 +185,129 @@
                   "required": [],
                   "title": "initContainers",
                   "type": "array"
+                },
+                "metrics": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "args",
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "command",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": false,
+                      "required": [],
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "env": {
+                      "properties": {
+                        "APIKEY": {
+                          "default": "",
+                          "required": [],
+                          "title": "APIKEY",
+                          "type": "string"
+                        },
+                        "URL": {
+                          "default": "http://localhost",
+                          "required": [],
+                          "title": "URL",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "env",
+                      "type": "object"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "envFrom",
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "required": [],
+                          "title": "pullPolicy",
+                          "type": "string"
+                        },
+                        "repository": {
+                          "default": "ghcr.io/onedr0p/exportarr",
+                          "required": [],
+                          "title": "repository",
+                          "type": "string"
+                        },
+                        "tag": {
+                          "default": "latest",
+                          "required": [],
+                          "title": "tag",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "image",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "required": [],
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "port": {
+                      "default": 9707,
+                      "required": [],
+                      "title": "port",
+                      "type": "integer"
+                    },
+                    "portName": {
+                      "default": "metrics-exporter",
+                      "required": [],
+                      "title": "portName",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "required": [],
+                      "title": "securityContext",
+                      "type": "object"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "required": []
+                      },
+                      "required": [],
+                      "title": "volumeMounts",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "metrics",
+                  "type": "object"
                 },
                 "nameOverride": {
                   "default": "",
@@ -600,81 +660,6 @@
       "title": "env",
       "type": "object"
     },
-    "exportarr": {
-      "properties": {
-        "enabled": {
-          "default": false,
-          "required": [],
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "env": {
-          "properties": {
-            "APIKEY": {
-              "default": "",
-              "required": [],
-              "title": "APIKEY",
-              "type": "string"
-            },
-            "URL": {
-              "default": "http://localhost:8989",
-              "required": [],
-              "title": "URL",
-              "type": "string"
-            }
-          },
-          "required": [
-            "URL",
-            "APIKEY"
-          ],
-          "title": "env",
-          "type": "object"
-        },
-        "image": {
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "required": [],
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "repository": {
-              "default": "ghcr.io/onedr0p/exportarr",
-              "required": [],
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
-              "required": [],
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository",
-            "tag",
-            "pullPolicy"
-          ],
-          "title": "image",
-          "type": "object"
-        },
-        "port": {
-          "default": 9707,
-          "required": [],
-          "title": "port",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enabled",
-        "image",
-        "port",
-        "env"
-      ],
-      "title": "exportarr",
-      "type": "object"
-    },
     "extraVolumeMounts": {
       "items": {
         "required": []
@@ -844,6 +829,81 @@
       "required": [],
       "title": "initContainers",
       "type": "array"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "APIKEY": {
+              "default": "",
+              "required": [],
+              "title": "APIKEY",
+              "type": "string"
+            },
+            "URL": {
+              "default": "http://localhost:8989",
+              "required": [],
+              "title": "URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "URL",
+            "APIKEY"
+          ],
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/onedr0p/exportarr",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v2.3.0@sha256:af535d94061cf97a52e1661945ffba78c03f9443eae7c0da1a80a5a4be56b520",
+              "required": [],
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "port": {
+          "default": 9707,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "port",
+        "env"
+      ],
+      "title": "metrics",
+      "type": "object"
     },
     "nameOverride": {
       "default": "",
@@ -1204,7 +1264,7 @@
     "probes",
     "resources",
     "serviceMonitor",
-    "exportarr",
+    "metrics",
     "gluetun",
     "nodeSelector",
     "tolerations",

--- a/charts/sonarr/values.yaml
+++ b/charts/sonarr/values.yaml
@@ -79,7 +79,7 @@ serviceMonitor:
   labels: {}
   annotations: {}
 
-exportarr:
+metrics:
   enabled: false
   image:
     repository: ghcr.io/onedr0p/exportarr


### PR DESCRIPTION
This PR updates the arr-common dependency version to 0.2.0 and replaces the `exportarr` sidecar with a more generically named `metrics` exporter sidecar. It also bumps the version of the charts and their shared dependency, `arr-common`,
